### PR TITLE
Add user table check to database status

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -250,7 +250,7 @@ def tests():
 
 @app.route('/database-status')
 def database_status():
-    """Check database connectivity and movie table status."""
+    """Check database connectivity and table status."""
     conn = get_db_connection()
     if not conn:
         return jsonify({"status": "error", "message": "Connection failed"}), 500
@@ -258,13 +258,26 @@ def database_status():
     try:
         with conn.cursor() as cursor:
             # Check if movie_ratings table exists
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT EXISTS (
-                    SELECT FROM information_schema.tables 
+                    SELECT FROM information_schema.tables
                     WHERE table_name = 'movie_ratings'
                 )
-            """)
+                """
+            )
             movie_table_exists = cursor.fetchone()[0]
+
+            # Check if users table exists
+            cursor.execute(
+                """
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables
+                    WHERE table_name = 'users'
+                )
+                """
+            )
+            user_table_exists = cursor.fetchone()[0]
             
             movie_count = 0
             if movie_table_exists:
@@ -274,6 +287,7 @@ def database_status():
             return jsonify({
                 "status": "connected",
                 "movie_table_exists": movie_table_exists,
+                "user_table_exists": user_table_exists,
                 "movie_count": movie_count,
                 "message": "Database connection successful"
             })

--- a/templates/tests.html
+++ b/templates/tests.html
@@ -230,13 +230,18 @@
                 
                 let statusMsg = `Database Status: ${data.status}\n`;
                 statusMsg += `Movie Table Exists: ${data.movie_table_exists ? '✅' : '❌'}\n`;
+                statusMsg += `User Table Exists: ${data.user_table_exists ? '✅' : '❌'}\n`;
                 statusMsg += `Movie Count: ${data.movie_count || 0}\n`;
-                
+
                 if (!data.movie_table_exists) {
                     statusMsg += '\n⚠️ Movie table does not exist! Click "Initialize Movie Tables" to create it.';
                 }
-                
-                showResult('db-status-result', statusMsg, data.movie_table_exists ? 'success' : 'error');
+                if (!data.user_table_exists) {
+                    statusMsg += '\n⚠️ Users table does not exist!';
+                }
+
+                const success = data.movie_table_exists && data.user_table_exists;
+                showResult('db-status-result', statusMsg, success ? 'success' : 'error');
             } catch (error) {
                 showResult('db-status-result', `Error: ${error.message}`, 'error');
             }
@@ -536,7 +541,7 @@
                 const dbData = await dbResponse.json();
                 results.push({
                     test: 'Database Status',
-                    passed: dbData.movie_table_exists,
+                    passed: dbData.movie_table_exists && dbData.user_table_exists,
                     details: dbData
                 });
             } catch (error) {


### PR DESCRIPTION
## Summary
- expand `/database-status` endpoint to check for the `users` table
- show `user_table_exists` flag in the test UI
- treat both tables as required for passing the database status test

## Testing
- `python -m py_compile api/index.py`
- `python -m py_compile api/db.py`


------
https://chatgpt.com/codex/tasks/task_e_6877ce98c39c8325aee8b0c015508515