### PR TITLE
Fix dynamic user list on homepage

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -117,6 +117,24 @@ def verify_user(user_name, password):
         conn.close()
 
 
+def get_all_users():
+    """Fetch a list of all user names."""
+    conn = get_db_connection()
+    if not conn:
+        return []
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT user_name FROM users ORDER BY user_name")
+            rows = cursor.fetchall()
+            return [row[0] for row in rows]
+    except Exception as e:
+        error_details = traceback.format_exc()
+        logger.error(f"Error fetching users: {e}\n{error_details}")
+        return []
+    finally:
+        conn.close()
+
+
 def init_movie_tables():
     """Initialize the movie ratings table."""
     # Ensure the users table exists first

--- a/api/index.py
+++ b/api/index.py
@@ -11,7 +11,8 @@ from .db import (
     update_elo_pair,
     delete_movie,
     create_user,
-    verify_user
+    verify_user,
+    get_all_users
 )
 import base64
 
@@ -87,6 +88,18 @@ def login():
         error_details = traceback.format_exc()
         logger.error(f"Error logging in: {e}\n{error_details}")
         return jsonify({'error': 'Login failed'}), 500
+
+
+@app.route('/api/users')
+def list_users():
+    """Return a list of all user names."""
+    try:
+        users = get_all_users()
+        return jsonify(users)
+    except Exception as e:
+        error_details = traceback.format_exc()
+        logger.error(f"Error fetching users: {e}\n{error_details}")
+        return jsonify({'error': 'Failed to fetch users'}), 500
 
 @app.route('/api/movies', methods=['GET'])
 def get_movies():

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,13 +9,11 @@
 <body>
     <div class="container">
         <h1>🎬 Movie Rankings</h1>
+        <p><a href="/tests">Go to Test Suite</a></p>
         
         <div class="user-controls">
             <label>Current User:</label>
-            <div class="button-group" id="user-buttons">
-                <button type="button" class="user-button active" data-user="Jack">Jack</button>
-                <button type="button" class="user-button" data-user="Guest">Guest</button>
-            </div>
+            <div class="button-group" id="user-buttons"></div>
             <button type="button" id="add-user-btn" class="add-user-btn">+ Add User</button>
         </div>
 

--- a/templates/tests.html
+++ b/templates/tests.html
@@ -122,6 +122,7 @@
 </head>
 <body>
     <h1>🎬 Movie Ratings Test Suite</h1>
+    <p><a href="/">Back to Main Page</a></p>
     
     <!-- Database Status -->
     <div class="test-section">


### PR DESCRIPTION
## Summary
- fetch users from backend and populate UI buttons
- add `/api/users` endpoint and helper to list users
- link main page to tests and vice versa

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877dba1ac948325a147e6a06514ad95