### PR TITLE
Add test suite and dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-postgresql

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import base64
+import pytest
+
+from api.index import app
+from api.db import init_movie_tables
+
+@pytest.fixture(scope="session")
+def client(postgresql):
+    os.environ['DATABASE_URL'] = postgresql.dsn()
+    init_movie_tables()
+    app.testing = True
+    with app.test_client() as client:
+        yield client
+
+
+def auth_headers(user, password):
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,10 @@
+
+def test_database_status_and_init(client):
+    resp = client.get('/database-status')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['status'] in ['connected', 'ok', 'success', 'connected']
+
+    resp = client.get('/init-movie-database')
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'success'

--- a/tests/test_movies.py
+++ b/tests/test_movies.py
@@ -1,0 +1,53 @@
+from tests.conftest import auth_headers
+
+
+def test_create_movie_authorized(client):
+    client.post('/register', json={'user_name': 'alice', 'password': 'pwd'})
+    headers = auth_headers('alice', 'pwd')
+
+    resp = client.post('/api/movies', json={
+        'user_name': 'alice',
+        'movie_title': 'Matrix',
+        'initial_rating': 'thumbs_up'
+    }, headers=headers)
+    assert resp.status_code == 201
+    movie = resp.get_json()['movie']
+    assert movie['movie_title'] == 'Matrix'
+
+
+def test_create_movie_unauthorized(client):
+    resp = client.post('/api/movies', json={
+        'user_name': 'someone',
+        'movie_title': 'Hackers',
+        'initial_rating': 'thumbs_up'
+    })
+    assert resp.status_code == 401
+
+
+def test_movie_listing_and_update(client):
+    client.post('/register', json={'user_name': 'bob', 'password': 'pwd'})
+    headers = auth_headers('bob', 'pwd')
+
+    r1 = client.post('/api/movies', json={'user_name': 'bob', 'movie_title': 'A', 'initial_rating': 'thumbs_up'}, headers=headers)
+    r2 = client.post('/api/movies', json={'user_name': 'bob', 'movie_title': 'B', 'initial_rating': 'okay'}, headers=headers)
+    id_a = r1.get_json()['movie']['id']
+    id_b = r2.get_json()['movie']['id']
+
+    # list with filter
+    resp = client.get('/api/movies?user=bob&category=thumbs_up')
+    assert resp.status_code == 200
+    assert len(resp.get_json()) == 1
+
+    # update elo
+    resp = client.put(f'/api/movies/{id_a}', json={'elo_rating': 4100}, headers=headers)
+    assert resp.status_code == 200
+
+    # compare movies
+    resp = client.post('/api/compare', json={'movie_a_id': id_a, 'movie_b_id': id_b, 'result': 'a'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['movie_a_id'] == id_a
+
+    # delete movie
+    resp = client.delete(f'/api/movies/{id_b}', headers=headers)
+    assert resp.status_code == 200

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,24 @@
+import json
+
+from tests.conftest import auth_headers
+
+
+def test_register_login_and_list_users(client):
+    # Register two users
+    resp = client.post('/register', json={'user_name': 'alice', 'password': 'pwd'})
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'success'
+
+    resp = client.post('/register', json={'user_name': 'bob', 'password': 'pwd'})
+    assert resp.status_code == 200
+
+    # Login with alice
+    resp = client.post('/login', json={'user_name': 'alice', 'password': 'pwd'})
+    assert resp.status_code == 200
+    assert resp.get_json()['status'] == 'success'
+
+    # List users should contain both
+    resp = client.get('/api/users')
+    assert resp.status_code == 200
+    users = resp.get_json()
+    assert 'alice' in users and 'bob' in users


### PR DESCRIPTION
## Summary
- add test client fixture using pytest-postgresql
- cover user flows, movie operations, and misc endpoints
- document dev dependencies for running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find Flask due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6877e2a6b3f08325a356333d9a7dc02e