### PR TITLE
Add admin interface and API endpoints

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,0 +1,97 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const usersDiv = document.getElementById('users');
+    const moviesDiv = document.getElementById('movies');
+    let authHeader = null;
+    let currentUser = null;
+
+    async function ensureAdmin() {
+        if (authHeader) return true;
+        const user = prompt('Admin username:');
+        const pass = prompt('Admin password:');
+        if (!user || !pass) return false;
+        authHeader = { 'Authorization': 'Basic ' + btoa(`${user}:${pass}`) };
+        const resp = await fetch('/admin/api/users', { headers: authHeader });
+        if (!resp.ok) {
+            alert('Invalid admin credentials');
+            authHeader = null;
+            return false;
+        }
+        return true;
+    }
+
+    async function loadUsers() {
+        if (!await ensureAdmin()) return;
+        const resp = await fetch('/admin/api/users', { headers: authHeader });
+        const users = await resp.json();
+        usersDiv.innerHTML = '';
+        moviesDiv.innerHTML = '';
+        users.forEach(u => {
+            const row = document.createElement('div');
+            row.textContent = u;
+            row.className = 'admin-user';
+            row.addEventListener('click', () => { currentUser = u; loadMovies(); });
+
+            const del = document.createElement('button');
+            del.textContent = 'Delete';
+            del.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                if (!confirm('Delete user and all movies?')) return;
+                const r = await fetch('/admin/api/users/' + encodeURIComponent(u), {
+                    method: 'DELETE',
+                    headers: authHeader
+                });
+                if (r.ok) loadUsers();
+            });
+            const pwd = document.createElement('button');
+            pwd.textContent = 'Change Password';
+            pwd.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                const np = prompt('New password for ' + u + ':');
+                if (!np) return;
+                await fetch('/admin/api/users/' + encodeURIComponent(u), {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json', ...authHeader },
+                    body: JSON.stringify({ password: np })
+                });
+            });
+            row.appendChild(del);
+            row.appendChild(pwd);
+            usersDiv.appendChild(row);
+        });
+    }
+
+    async function loadMovies() {
+        if (!currentUser) return;
+        const resp = await fetch(`/api/movies?user=${encodeURIComponent(currentUser)}`);
+        const movies = await resp.json();
+        moviesDiv.innerHTML = `<h3>Movies for ${currentUser}</h3>`;
+        movies.forEach(m => {
+            const row = document.createElement('div');
+            row.className = 'admin-movie';
+            const title = document.createElement('input');
+            title.value = m.movie_title;
+            const select = document.createElement('select');
+            ['thumbs_down','okay','thumbs_up'].forEach(opt => {
+                const o = document.createElement('option');
+                o.value = opt; o.textContent = opt; if (m.initial_rating === opt) o.selected = true;
+                select.appendChild(o);
+            });
+            const save = document.createElement('button');
+            save.textContent = 'Save';
+            save.addEventListener('click', async () => {
+                await fetch('/admin/api/movies/' + m.id, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json', ...authHeader },
+                    body: JSON.stringify({ movie_title: title.value, initial_rating: select.value })
+                });
+                loadMovies();
+            });
+            row.appendChild(title);
+            row.appendChild(select);
+            row.appendChild(save);
+            moviesDiv.appendChild(row);
+        });
+    }
+
+    loadUsers();
+});

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Panel</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <div class="container">
+        <h1>Admin Panel</h1>
+        <p>
+            <a href="/">Main Page</a> |
+            <a href="/tests">Tests</a>
+        </p>
+        <h2>Users</h2>
+        <div id="users"></div>
+        <h2>Movies</h2>
+        <div id="movies"></div>
+    </div>
+    <script src="{{ url_for('static', filename='js/admin.js') }}"></script>
+</body>
+</html>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -21,3 +21,4 @@
     <script src="{{ url_for('static', filename='js/admin.js') }}"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- create admin page template and script
- support admin user and routes in Flask app
- implement admin helpers in DB layer
- add client script for editing users and movies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6877ec49f08083258323350f26843b67