### PR TITLE
Remove duplicate admin route

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -312,15 +312,6 @@ def tests():
         logger.error(f"Error rendering tests page: {e}\n{error_details}")
         return "An error occurred loading the tests page.", 500
 
-@app.route('/admin')
-def admin_page():
-    """Renders the admin page."""
-    try:
-        return render_template('admin.html')
-    except Exception as e:
-        error_details = traceback.format_exc()
-        logger.error(f"Error rendering admin page: {e}\n{error_details}")
-        return "An error occurred loading the admin page.", 500
 
 @app.route('/database-status')
 def database_status():


### PR DESCRIPTION
## Summary
- remove the redundant `/admin` route handler in `api/index.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6877f63acca883258fa6fe30719fb71b