### PR TITLE
Add Elo rescaling feature

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -503,3 +503,76 @@ def admin_update_movie(movie_id, **fields):
         return False
     finally:
         conn.close()
+
+
+def rescale_user_elos(user_name):
+    """Rescale a user's movie ELOs using a piecewise linear transform.
+
+    Ratings are redistributed so the lowest rating maps toward 0, the
+    median maps to 3000 and the highest rating maps toward 5000.  This
+    keeps initial ratings around 2000/3000/4000 but ensures all values
+    stay within the global 0-5000 range.
+    """
+    conn = get_db_connection()
+    if not conn:
+        return False
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+            cursor.execute(
+                "SELECT id, elo_rating FROM movie_ratings WHERE user_name=%s ORDER BY elo_rating",
+                (user_name,),
+            )
+            rows = cursor.fetchall()
+            if not rows:
+                return True
+
+            elos = [row["elo_rating"] for row in rows]
+            min_elo = min(elos)
+            max_elo = max(elos)
+            mid_index = len(elos) // 2
+            if len(elos) % 2:
+                median = sorted(elos)[mid_index]
+            else:
+                ordered = sorted(elos)
+                median = (ordered[mid_index - 1] + ordered[mid_index]) / 2
+
+            updates = []
+            for row in rows:
+                rating = row["elo_rating"]
+                new_rating = rating
+                if rating <= median:
+                    if median == min_elo:
+                        new_rating = 0
+                    else:
+                        ratio = (rating - min_elo) / (median - min_elo)
+                        new_rating = ratio * 3000
+                else:
+                    if max_elo == median:
+                        new_rating = 5000
+                    else:
+                        ratio = (rating - median) / (max_elo - median)
+                        new_rating = 3000 + ratio * 2000
+                new_rating = max(0, min(5000, round(new_rating)))
+                updates.append((new_rating, row["id"]))
+
+            psycopg2.extras.execute_batch(
+                cursor,
+                "UPDATE movie_ratings SET elo_rating=%s, updated_at=CURRENT_TIMESTAMP WHERE id=%s",
+                updates,
+            )
+
+        update_rank_positions(user_name)
+        return True
+    except Exception as e:
+        error_details = traceback.format_exc()
+        logger.error(f"Error rescaling ELOs for {user_name}: {e}\n{error_details}")
+        return False
+    finally:
+        conn.close()
+
+
+def rescale_all_elos():
+    """Rescale ELOs for all users."""
+    for user in get_all_users():
+        rescale_user_elos(user)
+    return True

--- a/api/index.py
+++ b/api/index.py
@@ -15,7 +15,8 @@ from .db import (
     get_all_users,
     delete_user,
     update_user_password,
-    admin_update_movie
+    admin_update_movie,
+    rescale_all_elos
 )
 import base64
 
@@ -231,6 +232,19 @@ def admin_edit_movie(movie_id):
     if admin_update_movie(movie_id, **data):
         return jsonify({'status': 'success'})
     return jsonify({'error': 'Failed to update movie'}), 400
+
+
+@app.route('/admin/api/rescale_elos', methods=['POST'])
+def admin_rescale_elos():
+    if not _require_admin():
+        return jsonify({'error': 'Unauthorized'}), 401
+    try:
+        rescale_all_elos()
+        return jsonify({'status': 'success'})
+    except Exception as e:
+        error_details = traceback.format_exc()
+        logger.error(f"Error rescaling elos: {e}\n{error_details}")
+        return jsonify({'error': 'Failed to rescale elos'}), 500
 
 @app.route('/api/compare', methods=['POST'])
 def compare_movies():

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const usersDiv = document.getElementById('users');
     const moviesDiv = document.getElementById('movies');
     const addUserBtn = document.getElementById('admin-add-user');
+    const rescaleBtn = document.getElementById('rescale-elo-btn');
     let authHeader = null;
     let currentUser = null;
 
@@ -90,8 +91,8 @@ document.addEventListener('DOMContentLoaded', () => {
             row.appendChild(title);
             row.appendChild(select);
             row.appendChild(save);
-        moviesDiv.appendChild(row);
-    });
+            moviesDiv.appendChild(row);
+        });
     }
 
     if (addUserBtn) {
@@ -112,6 +113,24 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             loadUsers();
+        });
+    }
+
+    if (rescaleBtn) {
+        rescaleBtn.addEventListener('click', async () => {
+            if (!await ensureAdmin()) return;
+            if (!confirm('Rescale all Elo ratings?')) return;
+            const resp = await fetch('/admin/api/rescale_elos', {
+                method: 'POST',
+                headers: authHeader
+            });
+            if (resp.ok) {
+                alert('Elo ratings recalculated');
+                loadMovies();
+            } else {
+                const data = await resp.json().catch(() => ({}));
+                alert(data.error || 'Failed to rescale elos');
+            }
         });
     }
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -13,6 +13,9 @@
             <a href="/">Main Page</a> |
             <a href="/tests">Tests</a>
         </p>
+        <p>
+            <button type="button" id="rescale-elo-btn">Recalculate Elo</button>
+        </p>
         <h2>Users</h2>
         <button type="button" id="admin-add-user" class="add-user-btn">+ Add User</button>
         <div id="users"></div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from api.index import app
 from api.db import init_movie_tables
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def client(postgresql):
     os.environ['DATABASE_URL'] = postgresql.dsn()
     init_movie_tables()

--- a/tests/test_movies.py
+++ b/tests/test_movies.py
@@ -51,3 +51,40 @@ def test_movie_listing_and_update(client):
     # delete movie
     resp = client.delete(f'/api/movies/{id_b}', headers=headers)
     assert resp.status_code == 200
+
+
+def test_rescale_elos(client):
+    client.post('/register', json={'user_name': 'carol', 'password': 'pwd'})
+    headers = auth_headers('carol', 'pwd')
+
+    ids = []
+    for title in ['A', 'B', 'C']:
+        resp = client.post('/api/movies', json={
+            'user_name': 'carol',
+            'movie_title': title,
+            'initial_rating': 'okay'
+        }, headers=headers)
+        ids.append(resp.get_json()['movie']['id'])
+
+    client.put(f'/api/movies/{ids[0]}', json={'elo_rating': 2100}, headers=headers)
+    client.put(f'/api/movies/{ids[1]}', json={'elo_rating': 3100}, headers=headers)
+    client.put(f'/api/movies/{ids[2]}', json={'elo_rating': 3900}, headers=headers)
+
+    before = [m['elo_rating'] for m in client.get('/api/movies?user=carol').get_json()]
+
+    admin_headers = auth_headers('admin', 'adminpass')
+    resp = client.post('/admin/api/rescale_elos', headers=admin_headers)
+    assert resp.status_code == 200
+
+    movies = client.get('/api/movies?user=carol').get_json()
+    after = [m['elo_rating'] for m in movies]
+    assert after != before
+
+    # ensure values fall within allowed range
+    assert min(after) >= 0
+    assert max(after) <= 5000
+
+    for i in range(len(movies) - 1):
+        assert movies[i]['elo_rating'] >= movies[i + 1]['elo_rating']
+        assert movies[i]['rank_position'] == i + 1
+    assert movies[-1]['rank_position'] == len(movies)


### PR DESCRIPTION
## Summary
- add utilities to rescale user and global movie Elo ratings
- expose admin endpoint `POST /admin/api/rescale_elos`
- add UI button in admin panel to trigger recalculation
- wire frontend button to POST to endpoint
- extend tests for new functionality
- adjust rescaling to span 0..5000 rating range

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6878112f698c83258207154d96f85e83