### PR TITLE
Update Elo scale to 0-5000

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -16,7 +16,9 @@ from .db import (
     delete_user,
     update_user_password,
     admin_update_movie,
-    rescale_all_elos
+    rescale_all_elos,
+    MIN_ELO,
+    MAX_ELO,
 )
 import base64
 
@@ -208,8 +210,8 @@ def update_movie(movie_id):
         elo_rating = data['elo_rating']
         
         # Validate ELO range
-        if not isinstance(elo_rating, (int, float)) or elo_rating < 0 or elo_rating > 5000:
-            return jsonify({"error": "Invalid elo_rating (must be 0-5000)"}), 400
+        if not isinstance(elo_rating, (int, float)) or elo_rating < MIN_ELO or elo_rating > MAX_ELO:
+            return jsonify({"error": f"Invalid elo_rating (must be {MIN_ELO}-{MAX_ELO})"}), 400
             
         success = update_movie_elo(movie_id, int(elo_rating))
         

--- a/tests/test_movies.py
+++ b/tests/test_movies.py
@@ -84,3 +84,5 @@ def test_rescale_elos(client):
         assert movies[i]['elo_rating'] >= movies[i + 1]['elo_rating']
         assert movies[i]['rank_position'] == i + 1
     assert movies[-1]['rank_position'] == len(movies)
+    for m in movies:
+        assert 0 <= m['elo_rating'] <= 5000


### PR DESCRIPTION
## Summary
- define MIN_ELO/MAX_ELO and clamp Elo changes
- rescale movies to 0-5000 range
- validate Elo updates with new constants
- ensure test coverage checks Elo range after rescale

## Testing
- `pytest -q` *(fails: Could not found /usr/lib/postgresql/16/bin/pg_ctl)*

------
https://chatgpt.com/codex/tasks/task_e_687818c53dd88325a09f1e76a6ca45a7